### PR TITLE
adding and testing Indigo 5 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-indigo",
   "description": "Indigo plugin for homebridge: https://github.com/nfarina/homebridge",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "repository": {
     "type": "git",
     "url": "https://github.com/webdeck/homebridge-indigo.git"
@@ -13,7 +13,7 @@
   "bugs": {
     "url": "https://github.com/webdeck/homebridge-indigo/issues"
   },
-  "homepage": "https://github.com/rodtoll/homebridge-indigo",
+  "homepage": "https://github.com/webdeck/homebridge-indigo",
   "preferGlobal": true,
   "keywords": [
     "homebridge-plugin",
@@ -29,6 +29,7 @@
   "dependencies": {
     "async": "^1.4.2",
     "inherits": "^2.0.1",
-    "request": "2.49.x"
+    "request": "2.49.x",
+    "xml2json": "^0.9.0"
   }
 }


### PR DESCRIPTION
To use the XML RESTful API on an Indigo 5 system or for testing on any Indigo 6 system, add this line to ~/.homebridge/config.json in the middle of the "platforms" section:

```
"version": "5",
```

The version of xml2json I used as a dependency is https://github.com/buglabs/node-xml2json#readme, and also can be installed via

```
npm install [-g] xml2json
```

/Marty
