### PR TITLE
Consolidate Devices with identical hardware addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Configuration sample:
             "username": "myusername",
             "password": "mypassword",
             "includeActions": true,
+            "consolidateDevices": true,
             "includeIds": [ "12345", "67890" ],
             "excludeIds": [ "98765", "43210" ],
             "treatAsSwitchIds": [ "13579", "24680" ],
@@ -54,6 +55,7 @@ Fields:
 * "username": Username to log into Indigo web server, if applicable (optional)
 * "password": Password to log into Indigo web server, if applicable (optional)
 * "includeActions": If true, creates HomeKit switches for your actions (optional, defaults to false)
+* "consolidateDevices": If true, devices with the same device address will be seen in HomeKit as one device with multiple services.
 * "includeIds": Array of Indigo IDs to include (optional - if provided, only these Indigo IDs will map to HomeKit devices)
 * "excludeIds": Array of Indigo IDs to exclude (optional - if provided, these Indigo IDs will not be mapped to HomeKit devices)
 * "treatAsSwitchIds": Array of Indigo IDs to treat as switches (instead of lightbulbs) - devices must support on/off to qualify
@@ -70,6 +72,8 @@ expose everything, then omit both of these keys from your configuration.
 
 Also note that any Indigo devices or actions that have Remote Display unchecked in Indigo
 will NOT be exposed to HomeKit, because Indigo excludes those devices from its RESTful API.
+
+The consolidateDevices option is useful in situations such as with a FanLinc, where Indigo separates the fan controls and light controls each into their own separate device even though there is only one physical device.  With this option set to true HomeKit will show these controls under one device to reflect that.
 
 HomeKit limits bridges to 100 devices, so if you have more than 99 Indigo
 devices (and action groups, if you're including them), then you will want

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ Configuration example for your Homebridge config.json:
         "username": "myusername",
         "password": "mypassword",
         "includeActions": true,
+        "consolidateDevices": true,
         "includeIds": [ "12345", "67890" ],
         "excludeIds": [ "98765", "43210" ],
         "treatAsSwitchIds": [ "13579", "24680" ],
@@ -38,6 +39,7 @@ Fields:
     "username": Username to log into Indigo web server, if applicable (optional)
     "password": Password to log into Indigo web server, if applicable (optional)
     "includeActions": If true, creates HomeKit switches for your actions (optional, defaults to false)
+    "consolidateDevices": If true, devices with the same device address will be seen in HomeKit as one accessory with multiple services (optional, defaults to false)
     "includeIds": Array of Indigo IDs to include (optional - if provided, only these Indigo IDs will map to HomeKit devices)
     "excludeIds": Array of Indigo IDs to exclude (optional - if provided, these Indigo IDs will not be mapped to HomeKit devices)
     "treatAsSwitchIds": Array of Indigo IDs to treat as switches (instead of lightbulbs) - devices must support on/off to qualify
@@ -228,7 +230,27 @@ IndigoPlatform.prototype.addAccessory = function(item, callback) {
                 if (this.includeItemId(json.id)) {
                     var accessory = this.createAccessoryFromJSON(item.restURL, json);
                     if (accessory) {
-                        this.foundAccessories.push(accessory);
+                        var deviceLinked = false;
+                    	
+                    	if (this.consolidateDevices) {
+							for (var key in this.foundAccessories) {
+								if (this.foundAccessories.hasOwnProperty(key)) {
+									it = this.foundAccessories[key];
+							
+									if (accessory.addressStr != "unknown" && accessory.addressStr === it.addressStr) {
+										this.log("Consolidating: " + accessory.name + " Link to: " + it.name);
+										it.linkedDevices.push(accessory);
+										var deviceLinked = true;
+							
+										break;
+									}
+								}
+							}
+						}
+						
+						if (deviceLinked === false) {
+							this.foundAccessories.push(accessory);
+						}
                     } else {
                         this.log("Ignoring unknown accessory type %s", json.type);
                     }
@@ -341,6 +363,7 @@ function IndigoAccessory(platform, deviceURL, json) {
     this.platform = platform;
     this.log = platform.log;
     this.deviceURL = deviceURL;
+    this.linkedDevices = [];
 
     this.updateFromJSON(json);
 
@@ -360,7 +383,19 @@ function IndigoAccessory(platform, deviceURL, json) {
 }
 
 IndigoAccessory.prototype.getServices = function() {
-    return this.services;
+    var services = this.services;
+	
+	if (this.linkedDevices.length > 0) {
+		for (var key in this.linkedDevices) {
+			if (this.linkedDevices.hasOwnProperty(key)) {
+				it = this.linkedDevices[key];
+				
+				services = services.concat(it.getServices().slice(1));
+			}
+		}
+	}
+	
+    return services;
 };
 
 // Updates object fields with values from json

--- a/sampleconfig.json
+++ b/sampleconfig.json
@@ -19,6 +19,7 @@
             "username": "myusername",
             "password": "mypassword",
             "includeActions": true,
+            "consolidateDevices": true,
             "includeIds": [ "12345", "67890" ],
             "excludeIds": [ "98765", "43210" ],
             "treatAsSwitchIds": [ "13579", "24680" ],


### PR DESCRIPTION
I added a configurable option (called "consolidateDevices" in config.json) to consolidate Indigo devices that share a device address into a single accessory with multiple services.  An example of where this would be useful is for FanLinc devices: Indigo must report these as two separate devices (one to control the fan, and one to control the light) because of how it handles device type controls in its own GUI, however HomeKit supports having these controls listed under a single device which makes more sense since they are associated with one physical device in your home.
